### PR TITLE
Docker multi gui

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:24.04
+SHELL ["/bin/bash", "-c"]
+
+# --- Set up locale
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y locales
+
+RUN sed -i -e 's/# de_DE.UTF-8 UTF-8/de_DE.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=de_DE.UTF-8
+
+ENV LANG=de_DE.UTF-8 
+
+RUN apt-get install -y python3-dev \
+                       python3-pip
+
+
+RUN python3 -m pip config set global.break-system-packages true
+
+COPY requirements.txt /requirements.txt
+RUN pip install -r /requirements.txt
+
+# --- QT setup
+ENV QT_DEBUG_PLUGINS=1
+RUN apt-get install -y libxcb-icccm4-dev \
+ libxcb-image0-dev \
+ libxcb-keysyms1-dev \
+ libxcb-render-util0-dev \
+ libxcb-shape0-dev \
+ libxcb-xinerama0-dev
+
+# --- Xforwarding
+RUN apt-get install -y mesa-utils
+
+WORKDIR /
+CMD python3 /dance-cards/multi-gui.py

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,9 +1,9 @@
-# Multi GUI per Docker
+# Python-lose Multi GUI per Docker
 
-Dies ist eine Methode für ältere Systeme, deren Python Version unter 3.9 liegt.
+Für Ubuntu 20.04 und alle, deren Python Version unter 3.9 liegt.
 
 ```bash
-python --version # sollte mindestens 3.9 sein um die Skripte verwenden zu können
+python --version
 ```
 
 Um die Tanzauswahl zu starten und die individuellen Tänze zu erstellen kann Docker verwendet werden. Für das kompilieren der Tänze braucht es weiterhin die LaTeX installation.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,115 @@
+# Multi GUI per Docker
+
+Dies ist eine Methode für ältere Systeme, deren Python Version unter 3.9 liegt.
+
+```bash
+python --version # sollte mindestens 3.9 sein um die Skripte verwenden zu können
+```
+
+Um die Tanzauswahl zu starten und die individuellen Tänze zu erstellen kann Docker verwendet werden. Für das kompilieren der Tänze braucht es weiterhin die LaTeX installation.
+
+## Installation
+
+1. [Installiere Docker Compose](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository)
+
+   ```bash
+   # Add Docker's official GPG key:
+   sudo apt-get update
+   sudo apt-get install ca-certificates curl
+   sudo install -m 0755 -d /etc/apt/keyrings
+   sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+   sudo chmod a+r /etc/apt/keyrings/docker.asc
+   
+   # Add the repository to Apt sources:
+   echo \
+     "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+     $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+     sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+   sudo apt-get update
+   
+   # Install the docker packages
+   sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+   
+   # Test install for super-users
+   sudo docker run hello-world
+   
+   # Give user rights for docker
+   sudo groupadd docker
+   sudo usermod -aG docker $USER
+   newgrp docker
+   
+   # Test install for non super-user 
+   docker run hello-world
+   ```
+
+   Manchmal muss man sich ein mal aus und wieder einloggen, oder gar neu starten damit der User die Rechte bekommt.
+
+2. [Installiere TeX](https://github.com/Phayax/dance-cards/?tab=readme-ov-file#vorlage-weiterverwenden) falls nicht schon passiert.
+
+   ```bash
+   sudo apt install texstudio
+   sudo apt install texlive-full
+   ```
+
+3. Installiere xhost damit Docker UI Anwendungen starten kann
+
+   ```bash
+   sudo apt install xhost
+   ```
+
+## Verwendung
+
+1. Lade das Repository herunter
+
+   ```
+   git clone https://github.com/Phayax/dance-cards.git
+   ```
+
+2. [Erstelle die große PDF mit allen Tänzen](https://github.com/Phayax/dance-cards/?tab=readme-ov-file#erstellen)
+
+   ```bash
+   cd dance-cards
+   latexmk cards.tex
+   ```
+
+3. Spalte die Tänze in einzelne. 
+
+   ```bash
+   cd docker
+   docker compose up dance-cards-split
+   ```
+
+4. Repariere die Rechte an den Dateien, Docker hat sie für sich annektiert
+
+   ```bash
+   cd ..
+   sudo chown -R $USER split && sudo chgrp -R $USER split
+   ```
+
+5. Kompiliere die Tänze als einzelne PDFs
+
+   ```bash
+   latexmk split/*.tex
+   ```
+
+6. Erlaube Docker UI-Anwendungen zu öffnen
+
+   ```bash
+   xhost +local:docker
+   ```
+
+7. Starte die Tanzauswahl UI-Anwendung aus Docker
+
+   ```bash
+   cd docker
+   docker compose up dance-cards-gui
+   ```
+
+8. Wähle 
+
+   * im ersten Feld die große PDF
+   * im zweiten Feld den `split` Ordner
+
+   Es sollte nun alle Tänze in der Liste auftauchen. Fall nicht, stelle sicher, dass die Tänze in `split` als PDF kompliliert sind.
+
+9. Exportiere die gewünschten Formate und kompiliere die generierten Dateien mit `latexmk multi_cards_3x3_fold_long_.tex`

--- a/docker/README.md
+++ b/docker/README.md
@@ -89,7 +89,9 @@ Um die Tanzauswahl zu starten und die individuellen Tänze zu erstellen kann Doc
 5. Kompiliere die Tänze als einzelne PDFs
 
    ```bash
-   latexmk split/*.tex
+   cd split
+   latexmk *.tex
+   cd ..
    ```
 
 6. Erlaube Docker UI-Anwendungen zu öffnen

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,12 +5,21 @@ services:
       context: ../
       dockerfile: ./docker/Dockerfile
     image: arthurniedz/dance-cards
-    container_name: dance_cards_container
+    container_name: dance_cards_gui_container
     network_mode: host
     privileged: true
     environment:
       - DISPLAY=${DISPLAY}
     volumes:
       - ..:/dance-cards
-    command: python3 /dance-cards/multi-gui.py
-    
+    command: bash -c "cd /dance-cards && python3 multi-gui.py"
+  
+  dance-cards-split:
+    build:
+      context: ../
+      dockerfile: ./docker/Dockerfile
+    image: arthurniedz/dance-cards
+    container_name: dance_cards_split_container
+    volumes:
+      - ..:/dance-cards
+    command: bash -c "cd /dance-cards && python3 split.py"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,16 @@
+# docker-compose up
+services:  
+  dance-cards-gui:
+    build:
+      context: ../
+      dockerfile: ./docker/Dockerfile
+    image: arthurniedz/dance-cards
+    container_name: dance_cards_container
+    network_mode: host
+    privileged: true
+    environment:
+      - DISPLAY=${DISPLAY}
+    volumes:
+      - ..:/dance-cards
+    command: python3 /dance-cards/multi-gui.py
+    


### PR DESCRIPTION
Hi Sam,

das hier ist eine Lösung für alte Systeme mit Python version < 3.9 (mein Ubuntu 20.04 z.B.)

* Aus dem Dockerfile lässt sich die Installationsanleitung für Ubuntu 24.04 ableiten. Für QT5 musste ich einige libraries nachinstallieren
* Das docker-compose.yaml bietet zwei services
  * `dance-cards-split` für die split.py aus
  * `dance-cards-gui` startet die multi-gui. Hierfür nutzt er xhost für xforwarding auf x11 Systemen. 

Siehe auch das README.md zur Verwendung

Von mir aus kann der PR erstmal hier rumhängen. Ich brauche das Docker Setup hier noch und wollte es dir nicht vorenthalten.
